### PR TITLE
Add missing vg_options

### DIFF
--- a/services/cinder/cinder-volume.yaml
+++ b/services/cinder/cinder-volume.yaml
@@ -25,6 +25,7 @@
         vg: cinder-volumes
         pvs: "/dev/{{ volume_devices|join(',/dev/') }}"
         state: present
+        vg_options: ""
 
     - name: ensure {{ component }}-{{ subcomponent }} packages are installed
       apt: 


### PR DESCRIPTION
fixes failing "TASK: [create cinder-volumes volume group]"
