### PR TITLE
Install lvm2 package before creating volume group

### DIFF
--- a/services/cinder/cinder-volume.yaml
+++ b/services/cinder/cinder-volume.yaml
@@ -20,12 +20,6 @@
 
   tasks:
 
-    - name: create cinder-volumes volume group
-      lvg:
-        vg: cinder-volumes
-        pvs: "/dev/{{ volume_devices|join(',/dev/') }}"
-        state: present
-
     - name: ensure {{ component }}-{{ subcomponent }} packages are installed
       apt: 
         pkg: "{{ item }}"
@@ -33,6 +27,12 @@
         update_cache: yes 
         cache_valid_time: 600
       with_items: packages
+      
+    - name: create cinder-volumes volume group
+      lvg:
+        vg: cinder-volumes
+        pvs: "/dev/{{ volume_devices|join(',/dev/') }}"
+        state: present
 
     - name: ensure services are stopped
       service: 


### PR DESCRIPTION
Fixes:

TASK: [create cinder-volumes volume group] ***********************************\* 
failed: [storage] => {"failed": true}
msg: Failed to find required executable pvs
