### PR TITLE
Avoid special characters in ceilometer passwords

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -102,8 +102,8 @@ heat_mysql_password: "{{ lookup('password', inventory_dir + '/credentials/heat-m
 heat_identity_password: "{{ lookup('password', inventory_dir + '/credentials/heat-identity-password') }}"
 heat_rabbit_password: "{{ lookup('password', inventory_dir + '/credentials/heat-rabbit-password') }}"
 
-ceilometer_mongodb_password: "{{ lookup('password', inventory_dir + '/credentials/ceilometer-mongodb-password') }}"
-ceilometer_rabbit_password: "{{ lookup('password', inventory_dir + '/credentials/ceilometer-rabbit-password') }}"
-ceilometer_identity_password: "{{ lookup('password', inventory_dir + '/credentials/ceilometer-identity-password') }}"
+ceilometer_mongodb_password: "{{ lookup('password', inventory_dir + '/credentials/ceilometer-mongodb-password chars=ascii_letters,digits') }}"
+ceilometer_rabbit_password: "{{ lookup('password', inventory_dir + '/credentials/ceilometer-rabbit-password' chars=ascii_letters,digits) }}"
+ceilometer_identity_password: "{{ lookup('password', inventory_dir + '/credentials/ceilometer-identity-password chars=ascii_letters,digits') }}"
 metering_shared_secret: "{{ lookup('password', inventory_dir + '/credentials/metering-shared-secret') }}"
 


### PR DESCRIPTION
Fixes a problem when the auto-generated password contains a colon:
2014-04-11 05:42:18.175 12757 CRITICAL ceilometer [-] ':' or '@' characters in a username or password must be escaped according to RFC 2396.
