### PR TITLE
fix indentation of task that broke yaml

### DIFF
--- a/services/keystone/keystone.yaml
+++ b/services/keystone/keystone.yaml
@@ -100,7 +100,7 @@
         user: admin 
         role: admin
 
-   - name: create Member role and associate it with admin user
+    - name: create Member role and associate it with admin user
       keystone_user: 
         endpoint: "{{ keystone_admin_url }}"
         token: "{{ keystone_admin_token }}" 


### PR DESCRIPTION
Hello Lorin,

There is an indentation error in services/keystone/keystone.yaml which breaks the yaml format.

Cheers
