### PR TITLE
Non-admin users should be able to create swift containers

### DIFF
--- a/templates/etc/swift/proxy-server.conf
+++ b/templates/etc/swift/proxy-server.conf
@@ -12,7 +12,7 @@ account_autocreate = true
 
 [filter:keystoneauth]
 use = egg:swift#keystoneauth
-operator_roles = _member_,admin,swiftoperator
+operator_roles = Member,_member_,admin,swiftoperator
 
 [filter:authtoken]
 paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory


### PR DESCRIPTION
Fixes the issue described at http://openstack.redhat.com/forum/discussion/478/fedora-19-havana-swift-error-unable-to-list-containers-solved/p1
